### PR TITLE
feat: add reviewdog for better Github integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="ricardobchaves6@gmail.com"
 RUN apk add --no-cache \
     gcc \
     musl-dev && \
+    wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s v0.14.0 && \
     pip install pylint==2.7.4 \
     pylint_django==2.4.3 \
     pycodestyle==2.7.0 \


### PR DESCRIPTION
Reviewdog is tightly integrated with Github. Thus having comments from the Python linter displayed within Github UI would be highly beneficial. Thus adding reviewdog to the image.