### PR TITLE
Update package versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ LABEL maintainer="ricardobchaves6@gmail.com"
 RUN apk add --no-cache \
     gcc \
     musl-dev && \
-    pip install pylint==2.7.4 \
-    pylint_django==2.4.3 \
-    pycodestyle==2.7.0 \
-    flake8==3.9.1 \
-    black==20.8b1 \
-    mypy==0.812 \
-    isort==5.8.0
+    pip install pylint==2.15.8 \
+    pylint_django==2.5.3 \
+    pycodestyle==2.10.0 \
+    flake8==6.0.0 \
+    black==22.12.0 \
+    mypy==0.991 \
+    isort==5.11.2


### PR DESCRIPTION
## Summary

I am currently using the `python-lint` action as part of my workflow. Currently I'm only leveraging `pylint` and there was a need to suppress linting on a few particular paths in our project, however `pylint`'s `--ignore-paths` options is only available in a more recent version of `pylint` than what is currently specified in the Docker image.

So, long story short, I thought I'd try to update the `pylint` version being used as well as the other versions while I was at it. Looks like the last global update was over a year ago.

In any case - appreciate you writing a really helpful action for the community!